### PR TITLE
bump version to 0.4.2-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hiddenlayerai/hiddenlayer-sdk",
-  "version": "0.4.1-alpha",
+  "version": "0.4.2-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hiddenlayerai/hiddenlayer-sdk",
-      "version": "0.4.1-alpha",
+      "version": "0.4.2-alpha",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.529.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiddenlayerai/hiddenlayer-sdk",
-  "version": "0.4.1-alpha",
+  "version": "0.4.2-alpha",
   "description": "Official HiddenLayer TypeScript SDK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR:
* bumps the version to 0.4.2-alpha so we can get a release with the latest dependabot updates