### PR TITLE
INTR-131: update CI pipeline to not use the --legacy-peer-deps flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
                   node-version: ${{ matrix.node-version }}
 
             - name: Install modules
-              run: npm install --legacy-peer-deps
+              run: npm install
 
             - name: Cache node modules
               uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,11 +45,11 @@ jobs:
                 registry-url: 'https://registry.npmjs.org'
                 scope: '@hiddenlayerai'
             - name: Install modules
-              run: npm install --legacy-peer-deps
+              run: npm install
             - name: Build
               run: npm run build
             - name: Prune modules
-              run: npm prune --production --legacy-peer-deps
+              run: npm prune --production
             - name: Publish to npm
               run: npm publish --access public
               env:


### PR DESCRIPTION
## Describe your changes

Before, we used the `--legacy-peer-deps` flag because we had dependencies that had conflicting requirements and this enabled us to install the dependencies regardless.

Now that we have updated our dependencies based on dependabot PRs, I checked and the flag is no longer needed.  This PR removes it from our CI pipeline.
