### PR TITLE
INT-189: Support for re-scanning a given model version

### DIFF
--- a/hiddenlayer/services/ModelScanService.ts
+++ b/hiddenlayer/services/ModelScanService.ts
@@ -182,7 +182,7 @@ export class ModelScanService {
         const fileStats = await fs.promises.stat(modelPath);
         const fileSize = fileStats.size;
 
-        const model = await this.modelService.create(modelName, modelVersion);
+        const model = await this.modelService.createOrGet(modelName, modelVersion);
         const upload = await this.sensorApi.beginMultipartUpload({ xContentLength: fileSize, sensorId: model.sensorId });
 
         let file: fs.promises.FileHandle;

--- a/hiddenlayer/services/ModelService.ts
+++ b/hiddenlayer/services/ModelService.ts
@@ -1,4 +1,8 @@
 import { Model, SensorApi, ResponseError, Configuration } from "../../generated";
+import { sleep } from './utils';
+
+export class ModelNotFoundError extends Error {
+}
 
 export class ModelService {
     readonly sensorApi: SensorApi;
@@ -21,6 +25,49 @@ export class ModelService {
     }
 
     /**
+     * Creates a model in the HiddenLayer Platfom if it does not exist
+     * If the model and version already exists, returns the existing model.
+     *
+     * @param modelName Name of the model
+     * @param version Version of the model
+     *
+     * @returns Model
+     */
+    async createOrGet(modelName: string, version?: number): Promise<Model> {
+        try {
+            return await this.create(modelName, version);
+        } catch (error) {
+            if (error instanceof ResponseError && error.response.status == 400) {
+                const body = await error.response.text();
+                if (body.includes('already exists')) {
+                    return await this.getWithRetry(modelName, version, 3);
+                }
+            }
+            throw error;
+        }
+    }
+
+    async getWithRetry(modelName: string, version?: number, retries?: number): Promise<Model> {
+        let attempts = 0;
+        let model: Model;
+        const baseDelay = 0.1; // seconds
+        while (attempts < retries || 1) {
+            try {
+                model = await this.get(modelName, version);
+                return model;
+            } catch (error) {
+                if (error instanceof ModelNotFoundError) {
+                    sleep(baseDelay * Math.pow(2, attempts) + Math.random());
+                    attempts++;
+                } else {
+                    throw error;
+                }
+            }
+        }
+        throw new Error(`Model ${modelName} not found after ${retries} attempts`);
+    }
+
+    /**
      * Gets a HiddenLayer model object. If no version is supplied, the latest model is returned.
      * 
      * @param modelName Name of the model
@@ -28,7 +75,7 @@ export class ModelService {
      * 
      * @returns Model
      */
-    async get (modelName: string, version?: number): Promise<Model> {
+    async get(modelName: string, version?: number): Promise<Model> {
         const request = {
             sensorSORQueryRequest: {
                 filter: {
@@ -43,7 +90,7 @@ export class ModelService {
             if (version) {
                 msg += ` with version ${version}`;
             }
-            throw new Error(msg);
+            throw new ModelNotFoundError(msg);
         }
         if (!version) {
             // Sort by version in descending order

--- a/hiddenlayer/services/ModelService.ts
+++ b/hiddenlayer/services/ModelService.ts
@@ -50,8 +50,11 @@ export class ModelService {
     async getWithRetry(modelName: string, version?: number, retries?: number): Promise<Model> {
         let attempts = 0;
         let model: Model;
+        if (!retries) {
+            retries = 1;
+        }
         const baseDelay = 0.1; // seconds
-        while (attempts < retries || 1) {
+        while (attempts < retries) {
             try {
                 model = await this.get(modelName, version);
                 return model;


### PR DESCRIPTION
Prior to this change, if a user of the SDK submitted a model with the same model name and version, the system would reject it because `sensor with name/ version already exists`

The HiddenLayer platform does in fact allow re-scanning a given model version and our SDK should support that as well.  With this change, the SDK identifies when the sensor already exists and instead of attempting to create the sensor and ending up with the conflict, it uses the existing sensor and submits the model for re-scan
