### PR TITLE
ci: add release-please workflow (DIS-1082)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+on:
+  push:
+    branches: [next, main]
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-pr:
+    if: github.repository == 'hiddenlayerai/hiddenlayer-sdk-typescript' && github.ref == 'refs/heads/next'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: next
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Install release-please
+        run: npm install -g "git+https://github.com/stainless-api/release-please.git#a116e1e520e0f87824acf46a2e79c91d41e819d7"
+
+      - name: Create or update release PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          release-please release-pr \
+            --token "$GITHUB_TOKEN" \
+            --repo-url "$GITHUB_REPOSITORY" \
+            --target-branch main \
+            --changes-branch next
+
+  release:
+    if: github.repository == 'hiddenlayerai/hiddenlayer-sdk-typescript' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Install release-please
+        run: npm install -g "git+https://github.com/stainless-api/release-please.git#a116e1e520e0f87824acf46a2e79c91d41e819d7"
+
+      - name: Create GitHub release
+        id: gh-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          output=$(release-please github-release \
+            --token "$GITHUB_TOKEN" \
+            --repo-url "$GITHUB_REPOSITORY" \
+            --target-branch main \
+            --changes-branch next 2>&1) || true
+          echo "$output"
+          if echo "$output" | grep -q '"tagName"'; then
+            tag=$(echo "$output" | grep -oP '"tagName":\s*"\K[^"]+')
+            echo "created=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          else
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch publish
+        if: steps.gh-release.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: gh workflow run publish-npm.yml --ref "${{ steps.gh-release.outputs.tag }}"
+
+      - name: Reset next to main
+        if: steps.gh-release.outputs.created == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          git fetch origin main next
+          git checkout -B next origin/main
+          git push --force-with-lease origin next


### PR DESCRIPTION
## Summary

- Adds `release.yml` workflow that runs the [Stainless release-please fork](https://github.com/stainless-api/release-please) in-house, replacing the hosted SaaS.
- On push to `next`: opens or updates a release PR against `main` with an auto-generated changelog and version bump.
- On push to `main` (merged release PR): cuts a GitHub Release + tag, dispatches `publish-npm.yml` at the release tag, then resets `next` to `main`.
- Fork pinned at SHA `a116e1e520e0f87824acf46a2e79c91d41e819d7`.
- Authenticated with `RELEASE_PLEASE_TOKEN` (fine-grained PAT) so pushes trigger CI and the publish dispatch fires.

## Prereqs

- [ ] `RELEASE_PLEASE_TOKEN` secret set in this repo

## Test plan

- [ ] Push to `next` triggers the `release-pr` job and opens a release PR against `main`
- [ ] Release PR carries correct changelog and version bump from `release-please-config.json`
- [ ] Merging the release PR to `main` triggers the `release` job, creates a GitHub Release, and dispatches `publish-npm.yml`
- [ ] After release, `next` is reset to `main`