### PR TITLE
fix(ci): use pnpm with the fork's lockfile instead of npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,14 @@ jobs:
           node-version: '20'
 
       - name: Install release-please
-        run: npm install -g "git+https://github.com/stainless-api/release-please.git#a116e1e520e0f87824acf46a2e79c91d41e819d7"
+        run: |
+          git clone https://github.com/stainless-api/release-please.git /tmp/release-please
+          cd /tmp/release-please
+          git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
+          corepack enable
+          pnpm install
+          pnpm run build
+          npm link
 
       - name: Create or update release PR
         env:
@@ -54,7 +61,14 @@ jobs:
           node-version: '20'
 
       - name: Install release-please
-        run: npm install -g "git+https://github.com/stainless-api/release-please.git#a116e1e520e0f87824acf46a2e79c91d41e819d7"
+        run: |
+          git clone https://github.com/stainless-api/release-please.git /tmp/release-please
+          cd /tmp/release-please
+          git checkout a116e1e520e0f87824acf46a2e79c91d41e819d7
+          corepack enable
+          pnpm install
+          pnpm run build
+          npm link
 
       - name: Create GitHub release
         id: gh-release


### PR DESCRIPTION
## Summary

The release-please fork uses pnpm and ships a `pnpm-lock.yaml`. The previous install used `npm install`, which ignores the lockfile and resolves latest-compatible transitive dependencies — causing Octokit type drift that breaks `tsc`.

Switches to the fork's actual build process: `corepack enable`, `pnpm install` (respects the lockfile), `pnpm run build`, `npm link`.

Validated locally and proven on the Python SDK (PR #219 opened successfully).

## Test plan

- [ ] Release workflow install step succeeds
- [ ] `release-please release-pr` opens/updates a release PR against `main`