### PR TITLE
chore(ci): remove Stainless branch filters (DIS-1083)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,8 @@ on:
   push:
     branches:
       - '**'
-      - '!integrated/**'
-      - '!stl-preview-head/**'
-      - '!stl-preview-base/**'
-      - '!generated'
       - '!codegen/**'
-      - 'codegen/stl/**'
   pull_request:
-    branches-ignore:
-      - 'stl-preview-head/**'
-      - 'stl-preview-base/**'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

- Remove dead Stainless branch exclusions from CI push triggers (`integrated/**`, `stl-preview-*`, `generated`, `codegen/stl/**`)
- Remove Stainless branch patterns from pull_request `branches-ignore`
- Retain `!codegen/**` exclusion to prevent duplicate CI on codegen branch pushes (CI runs on the PR instead)

## Test plan

- [ ] CI runs on this PR (proves the trigger changes don't break anything)